### PR TITLE
Revert "[WIP]Gemfileの修正"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,17 @@ gem 'jbuilder', '~> 2.5'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem 'devise'
+  gem 'font-awesome-rails'
+  gem 'haml-rails'
+  gem 'erb2haml'
+  gem 'pry-rails'
+  gem 'carrierwave'
+  gem 'mini_magick'
+  gem 'rspec-rails'
+  gem 'rails-controller-testing'
+  gem 'factory_girl_rails'
+  gem 'faker'
 end
 
 group :development do
@@ -58,15 +69,3 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 group :production do
   gem 'unicorn'
 end
-
-gem 'devise'
-gem 'font-awesome-rails'
-gem 'haml-rails'
-gem 'erb2haml'
-gem 'pry-rails'
-gem 'carrierwave'
-gem 'mini_magick'
-gem 'rspec-rails'
-gem 'rails-controller-testing'
-gem 'factory_girl_rails'
-gem 'faker'


### PR DESCRIPTION
## WHY
Gemfileの修正のためのブランチ(#15)をマスターブランチにマージする際にタイトルから[WIP]を外すことを忘れたため、元に戻す処理を行う。