### PR TITLE
.gitignoreの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@
 # Ignore Byebug command history file.
 .byebug_history
 
-/public/images
 /public/uploads


### PR DESCRIPTION
## WHAT
.gitignoreの修正

## WHY
AWSでRailsを起動する際にエラーが発生し、そのエラー文に.gitignoreに関する記述があるため修正する